### PR TITLE
Add dedicated tutorial pages with new-window links

### DIFF
--- a/public/tutorials/advanced-typescript-patterns.html
+++ b/public/tutorials/advanced-typescript-patterns.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Advanced TypeScript Patterns</title>
+</head>
+<body>
+  <h1>Advanced TypeScript Patterns</h1>
+  <p>Learn advanced TypeScript features like conditional types and mapped types.</p>
+</body>
+</html>

--- a/public/tutorials/css-grid-flexbox.html
+++ b/public/tutorials/css-grid-flexbox.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>CSS Grid and Flexbox</title>
+</head>
+<body>
+  <h1>CSS Grid and Flexbox</h1>
+  <p>Master modern CSS layout techniques.</p>
+</body>
+</html>

--- a/public/tutorials/javascript-fundamentals.html
+++ b/public/tutorials/javascript-fundamentals.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>JavaScript Fundamentals</title>
+</head>
+<body>
+  <h1>JavaScript Fundamentals</h1>
+  <p>Learn the basics of JavaScript including variables, functions, and control structures.</p>
+</body>
+</html>

--- a/public/tutorials/nodejs-api-development.html
+++ b/public/tutorials/nodejs-api-development.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Node.js API Development</title>
+</head>
+<body>
+  <h1>Node.js API Development</h1>
+  <p>Build RESTful APIs with Node.js and Express.</p>
+</body>
+</html>

--- a/public/tutorials/python-data-science.html
+++ b/public/tutorials/python-data-science.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Python Data Science</title>
+</head>
+<body>
+  <h1>Python Data Science</h1>
+  <p>Introduction to data analysis and visualization with Python.</p>
+</body>
+</html>

--- a/public/tutorials/react-hooks-deep-dive.html
+++ b/public/tutorials/react-hooks-deep-dive.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>React Hooks Deep Dive</title>
+</head>
+<body>
+  <h1>React Hooks Deep Dive</h1>
+  <p>Master React hooks including useState, useEffect, and custom hooks.</p>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ interface Tutorial {
   difficulty: 'Beginner' | 'Intermediate' | 'Advanced'
   duration: string
   category: string
+  link: string
 }
 
 interface Tool {
@@ -309,42 +310,48 @@ function TutorialsPage() {
       description: "Learn the basics of JavaScript including variables, functions, and control structures.",
       difficulty: "Beginner",
       duration: "2 hours",
-      category: "Web Development"
+      category: "Web Development",
+      link: "/tutorials/javascript-fundamentals.html"
     },
     {
       title: "React Hooks Deep Dive",
       description: "Master React hooks including useState, useEffect, and custom hooks.",
       difficulty: "Intermediate",
       duration: "3 hours",
-      category: "React"
+      category: "React",
+      link: "/tutorials/react-hooks-deep-dive.html"
     },
     {
       title: "Python Data Science",
       description: "Introduction to data analysis and visualization with Python.",
       difficulty: "Beginner",
       duration: "4 hours",
-      category: "Data Science"
+      category: "Data Science",
+      link: "/tutorials/python-data-science.html"
     },
     {
       title: "Advanced TypeScript Patterns",
       description: "Learn advanced TypeScript features like conditional types and mapped types.",
       difficulty: "Advanced",
       duration: "5 hours",
-      category: "TypeScript"
+      category: "TypeScript",
+      link: "/tutorials/advanced-typescript-patterns.html"
     },
     {
       title: "Node.js API Development",
       description: "Build RESTful APIs with Node.js and Express.",
       difficulty: "Intermediate",
       duration: "6 hours",
-      category: "Backend"
+      category: "Backend",
+      link: "/tutorials/nodejs-api-development.html"
     },
     {
       title: "CSS Grid and Flexbox",
       description: "Master modern CSS layout techniques.",
       difficulty: "Beginner",
       duration: "2.5 hours",
-      category: "CSS"
+      category: "CSS",
+      link: "/tutorials/css-grid-flexbox.html"
     }
   ]
 
@@ -407,7 +414,11 @@ function TutorialsPage() {
                 <span className="text-sm text-muted-foreground">{tutorial.category}</span>
                 <span className="text-sm font-medium">{tutorial.duration}</span>
               </div>
-              <Button className="w-full mt-4" variant="outline">
+              <Button
+                className="w-full mt-4"
+                variant="outline"
+                onClick={() => window.open(tutorial.link, '_blank')}
+              >
                 Start Tutorial
               </Button>
             </CardContent>


### PR DESCRIPTION
## Summary
- add link field to tutorials and open tutorial pages in a new tab
- create static HTML pages for each tutorial in `public/tutorials`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_68ba7b7316e88330864495480b8f2e75